### PR TITLE
fix: screencap/snapshot command

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,14 +945,14 @@ hdc提供了两种截图命令
 $ hdc shell uitest screenCap
 // 默认存储路径：/data/local/tmp，文件名：时间戳 + .png。
 
-$ hdc shell uitest screenCap -p /data/local/1.png
+$ hdc shell uitest screenCap -p /data/local/tmp/1.png
 // 指定存储路径和文件名。
 ```
 
 
 【推荐】方式二
 ```
-$ hdc shell snapshot_display -f /data/local/2.png
+$ hdc shell snapshot_display -f /data/local/tmp/2.jpeg
 // 截图完成后可以通过 hdc file recv 命令导入到本地
 ```
 


### PR DESCRIPTION
```
~ $ hdc shell uitest screenCap -p /data/local/1.png
INFO:             Vulkan Loader Version 1.3.250
File opening failed: Bad file descriptor
ScreenCap failed: File opening failed
~ $ hdc shell uitest screenCap -p /data/local/tmp/1.png
INFO:             Vulkan Loader Version 1.3.250
ScreenCap saved to /data/local/tmp/1.png
~ $ hdc shell snapshot_display -f /data/local/2.png
INFO:             Vulkan Loader Version 1.3.250
error: fileName /data/local/2.png invalid, realpath /data/local must dump at dir: /data/local/tmp
error: filename /data/local/2.png invalid!
~ $ hdc shell snapshot_display -f /data/local/tmp/2.png
INFO:             Vulkan Loader Version 1.3.250
error: fileName /data/local/tmp/2.png invalid, suffix must be .jpeg
error: filename /data/local/tmp/2.png invalid!
~ $ hdc shell snapshot_display -f /data/local/tmp/2.jpeg
INFO:             Vulkan Loader Version 1.3.250
process: display 0: width 1260, height 2720
snapshot: pixel format is: 3
snapshot: convert rgba8888 to rgb888 successfully.

success: snapshot display 0 , write to /data/local/tmp/2.jpeg as jpeg, width 1260, height 2720
```